### PR TITLE
Skip extraction when svm-rollup tarball is empty (user declined update)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -158,7 +158,7 @@ fi
 
 check_and_download "$SVM_URL" "$SVM_TARBALL" "svm-rollup"
 
-if [[ -f "$SVM_TARBALL" ]]; then
+if [[ -f "$SVM_TARBALL" && -s "$SVM_TARBALL" ]]; then
     log "Extracting svm-rollup..."
     pv "$SVM_TARBALL" | tar xzf - --strip-components=1 2>/dev/null || tar xzf "$SVM_TARBALL" --strip-components=1
     rm -f "$SVM_TARBALL"


### PR DESCRIPTION
The touch -r command creates a 0-byte dummy tarball as a timestamp reference for check_and_download. When the user declines the update, this empty file remains and the extraction step fails with "unexpected end of file". Add -s check to only extract when the tarball has actual content.