### PR TITLE
Add 60s tolerance to version freshness check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,7 @@ check_and_download() {
     local remote_epoch
     remote_epoch=$(date -d "$remote_date" +%s 2>/dev/null || echo 0)
 
-    if [[ "$remote_epoch" -gt "$local_epoch" ]]; then
+    if [[ "$remote_epoch" -gt $((local_epoch + 60)) ]]; then
         local local_date
         local_date=$(date -d "@$local_epoch" '+%Y-%m-%d %H:%M' 2>/dev/null || echo "unknown")
         local remote_pretty


### PR DESCRIPTION
The local file timestamp (from stat) and the remote Last-Modified header can differ by a few seconds even for the same file, causing a false "newer version available" prompt. Add a 60-second tolerance so files within the same minute are treated as up to date.